### PR TITLE
Remove upper version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "ext-mongo": ">=1.2.12,<1.6-dev",
+        "ext-mongo": ">=1.2.12",
         "zendframework/zendframework1": "*"
     },
     "autoload": {


### PR DESCRIPTION
The default minimum stability will prevent development versions
https://getcomposer.org/doc/04-schema.md#minimum-stability